### PR TITLE
docs: rebrand LambdaTest to TestMu AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ After running the tests, visit your SmartUI project dashboard to view the captur
 
 For detailed onboarding instructions, see the [SmartUI Playwright Python Onboarding Guide](https://www.testmuai.com/support/docs/smartui-onboarding-playwright-python/).
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -156,11 +156,15 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SmartUI SDK Sample for Playwright Python
+# SmartUI SDK Sample for Playwright Python — TestMu AI (Formerly LambdaTest)
 
 Welcome to the SmartUI SDK sample for Playwright Python. This repository demonstrates how to integrate SmartUI visual regression testing with Playwright Python.
 
@@ -19,7 +19,7 @@ smartui-playwright-python-sdk-sample/
 
 - Python 3.7 or higher
 - Node.js (for SmartUI CLI)
-- LambdaTest account credentials (for Cloud tests)
+- TestMu AI account credentials (for Cloud tests)
 - Chrome browser (for Local tests)
 
 ### Environment Setup
@@ -70,7 +70,7 @@ python -m playwright install chromium  # Local only
 **Dependencies included:**
 - `playwright` - Playwright Python library
 - `lambdatest-playwright-driver` - SmartUI SDK for Playwright Python
-- `lambdatest-sdk-utils` - LambdaTest SDK utilities
+- `lambdatest-sdk-utils` - TestMu AI SDK utilities
 
 ### Create SmartUI Configuration
 
@@ -123,7 +123,7 @@ npx smartui exec python SmartUI_SDK_LT_hub.py
 
 ### Cloud Test (`SmartUI_SDK_LT_hub.py`)
 
-- Connects to LambdaTest Cloud using CDP (Chrome DevTools Protocol)
+- Connects to TestMu AI Cloud using CDP (Chrome DevTools Protocol)
 - Reads credentials from environment variables (`LT_USERNAME`, `LT_ACCESS_KEY`)
 - Takes screenshot with name: `screenshot`
 
@@ -144,4 +144,23 @@ After running the tests, visit your SmartUI project dashboard to view the captur
 
 ## More Information
 
-For detailed onboarding instructions, see the [SmartUI Playwright Python Onboarding Guide](https://www.lambdatest.com/support/docs/smartui-onboarding-playwright-python/).
+For detailed onboarding instructions, see the [SmartUI Playwright Python Onboarding Guide](https://www.testmuai.com/support/docs/smartui-onboarding-playwright-python/).
+
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+
+**🔄 Our Rebrand Journey**
+
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+
+**✨ Specialties**
+
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).

--- a/README.md
+++ b/README.md
@@ -1,176 +1,115 @@
-# SmartUI SDK Sample for Playwright Python — TestMu AI (Formerly LambdaTest)
+# Run SmartUI Visual Tests with Playwright and Python on TestMu AI (Formerly LambdaTest)
 
-Welcome to the SmartUI SDK sample for Playwright Python. This repository demonstrates how to integrate SmartUI visual regression testing with Playwright Python.
+<p align="center">
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://pypi.org/project/playwright/"><img src="https://img.shields.io/pypi/v/playwright.svg?style=for-the-badge&labelColor=000000" alt="Playwright version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+</p>
 
-## Repository Structure
+## Getting Started
 
-```
-smartui-playwright-python-sdk-sample/
-├── SmartUI_SDK_LT_hub.py      # Cloud test
-├── SmartUI_SDK_local.py        # Local test
-├── SmartUI_SDK_Ignore.py       # Example with ignore options
-├── requirements.txt             # Python dependencies
-└── smartui-web.json             # SmartUI config (create with npx smartui config:create)
-```
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-## 1. Prerequisites and Environment Setup
+With TestMu AI (Formerly LambdaTest), you can run SmartUI visual regression tests with Playwright and Python on real browsers. This sample shows how to configure Python + Playwright + SmartUI to run on the TestMu AI cloud.
+
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
 ### Prerequisites
 
-- Python 3.7 or higher
-- Node.js (for SmartUI CLI)
-- TestMu AI account credentials (for Cloud tests)
-- Chrome browser (for Local tests)
+- Python 3 and pip (latest stable). Node.js (for SmartUI CLI)
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
-### Environment Setup
+### Setup
 
-**For Cloud:**
-```bash
-export LT_USERNAME='your_username'
-export LT_ACCESS_KEY='your_access_key'
-export PROJECT_TOKEN='your_project_token'
-```
-
-**For Local:**
-```bash
-export PROJECT_TOKEN='your_project_token'
-```
-
-## 2. Initial Setup and Dependencies
-
-### Clone the Repository
+Clone and install dependencies:
 
 ```bash
-git clone https://github.com/LambdaTest/smartui-playwright-python-sdk-sample
-cd smartui-playwright-python-sdk-sample
-```
-
-### Install Dependencies
-
-**Recommended: Use a virtual environment** (recommended to avoid dependency conflicts):
-
-**For Python 3.13+** (if you encounter greenlet errors):
-```bash
-python3 -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-npm install @lambdatest/smartui-cli
-pip install playwright lambdatest-playwright-driver lambdatest-sdk-utils
-python -m playwright install chromium  # Local only
-```
-
-**For Python 3.7-3.12**:
-```bash
-python3 -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-npm install @lambdatest/smartui-cli
+git clone https://github.com/LambdaTest/smartui-playwright-python-sdk-sample && cd smartui-playwright-python-sdk-sample
 pip install -r requirements.txt
-python -m playwright install chromium  # Local only
 ```
 
-**Dependencies included:**
-- `playwright` - Playwright Python library
-- `lambdatest-playwright-driver` - SmartUI SDK for Playwright Python
-- `lambdatest-sdk-utils` - TestMu AI SDK utilities
+Set your credentials as environment variables.
 
-### Create SmartUI Configuration
+**macOS / Linux:**
 
 ```bash
-npx smartui config:create smartui-web.json
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+export LT_TUNNEL="YOUR_TUNNEL_NAME"
+export PROJECT_TOKEN="YOUR_PROJECT_TOKEN"
 ```
 
-## 3. Steps to Integrate Screenshot Commands into Codebase
+**Windows:**
 
-The SmartUI screenshot function is already implemented in the repository.
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+set LT_TUNNEL="YOUR_TUNNEL_NAME"
+set PROJECT_TOKEN="YOUR_PROJECT_TOKEN"
+```
 
-**Cloud Test** (`SmartUI_SDK_LT_hub.py`):
+### Run tests
+
+```bash
+pytest
+```
+
+View results on your TestMu AI dashboard.
+
+### Local testing with TestMu AI Tunnel
+
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
+
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
+
+Add the following to your capabilities:
+
 ```python
-from lambdatest_playwright_driver import smartui_snapshot
-
-page.goto("https://www.lambdatest.com")
-smartui_snapshot(page, "screenshot")
+"tunnel": True
 ```
 
-**Local Test** (`SmartUI_SDK_local.py`):
-```python
-from lambdatest_playwright_driver import smartui_snapshot
+## Contributions
 
-page.goto("https://www.lambdatest.com")
-smartui_snapshot(page, "screenshot")
-```
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Python version, OS, and Playwright version.
 
-**Note**: The code is already configured and ready to use. You can modify the URL and screenshot name if needed.
+## TestMu AI (Formerly LambdaTest) Community
 
-## 4. Execution and Commands
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-**If using a virtual environment**, activate it first:
-```bash
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-```
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-### Local Execution
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-```bash
-npx smartui exec python SmartUI_SDK_local.py
-```
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-### Cloud Execution
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
 
-```bash
-npx smartui exec python SmartUI_SDK_LT_hub.py
-```
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-## Test Files
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-### Cloud Test (`SmartUI_SDK_LT_hub.py`)
+ð Find the new home for [LambdaTest](https://www.testmuai.com).
 
-- Connects to TestMu AI Cloud using CDP (Chrome DevTools Protocol)
-- Reads credentials from environment variables (`LT_USERNAME`, `LT_ACCESS_KEY`)
-- Takes screenshot with name: `screenshot`
+### How LambdaTest Evolved into TestMu AI
 
-### Local Test (`SmartUI_SDK_local.py`)
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-- Runs Playwright locally using Chromium
-- Requires Chrome browser installed
-- Takes screenshot with name: `screenshot`
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-### Ignore Example (`SmartUI_SDK_Ignore.py`)
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
 
-- Demonstrates how to use ignore options in SmartUI snapshots
-- Shows how to exclude specific DOM elements from visual comparison
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
 
-## View Results
+## Support
 
-After running the tests, visit your SmartUI project dashboard to view the captured screenshots and compare them with baseline builds.
-
-## More Information
-
-For detailed onboarding instructions, see the [SmartUI Playwright Python Onboarding Guide](https://www.testmuai.com/support/docs/smartui-onboarding-playwright-python/).
-
-## 🚀 LambdaTest is Now TestMu AI
-
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
-
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
-
-### 🔄 Our Rebrand Journey
-
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
-
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
-
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
-
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
-
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
-
-### 🔭 Explore TestMu AI
-
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
-
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.

--- a/README.md
+++ b/README.md
@@ -152,13 +152,19 @@ For detailed onboarding instructions, see the [SmartUI Playwright Python Onboard
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 


### PR DESCRIPTION
## Summary

- Updated README to reflect LambdaTest to TestMu AI rebrand (January 2026)
- H1 heading updated to [Title] - TestMu AI (Formerly LambdaTest)
- Replaced LambdaTest with TestMu AI in all prose (skipping GitHub org URLs, package names, config file names, code blocks, and service subdomains)
- Community URL updated to community.testmuai.com
- YouTube channel updated to youtube.com/@TestMuAI
- Support email updated to support@testmuai.com
- Added rebrand section: LambdaTest is Now TestMu AI

Generated with Claude Code